### PR TITLE
Makes assistant show up as "REDACTED" rather than literally not a job

### DIFF
--- a/maps/oldfare/jobs/warfare_jobs.dm
+++ b/maps/oldfare/jobs/warfare_jobs.dm
@@ -39,6 +39,6 @@
 		default_language = L
 
 /datum/job/assistant
-	title = "literally not a job"
+	title = "REDACTED"
 	total_positions = 0
 	spawn_positions = 0


### PR DESCRIPTION
Looks a bit tiny cleaner than literally not a job.