### PR TITLE
Armaggedon belt

### DIFF
--- a/maps/oldfare/jobs/blue/blue_soldiers.dm
+++ b/maps/oldfare/jobs/blue/blue_soldiers.dm
@@ -246,7 +246,8 @@
 	else if (prob(5))
 		suit_store = /obj/item/gun/projectile/automatic/m22/warmonger/m14/battlerifle/rsc
 		r_pocket =  /obj/item/ammo_magazine/a762/rsc
-		backpack_contents = list(/obj/item/ammo_magazine/a762/rsc = 4, /obj/item/grenade/smokebomb = 1)
+		backpack_contents = list(/obj/item/grenade/smokebomb = 1)
+		belt = /obj/item/storage/belt/armageddon
 
 	else if(prob(25))
 		suit_store = /obj/item/gun/projectile/shotgun/pump/boltaction/shitty/leverchester
@@ -263,8 +264,7 @@
 		r_pocket = /obj/item/ammo_box/rifle
 		backpack_contents = list(/obj/item/grenade/smokebomb = 1)
 	if(aspect_chosen(/datum/aspect/nightfare))
-		backpack_contents += list(/obj/item/torch/self_lit = 1)
-		belt = /obj/item/ammo_box/flares/blue
+		backpack_contents += list(/obj/item/torch/self_lit = 1, /obj/item/ammo_box/flares/blue = 1)
 	..()
 
 
@@ -281,11 +281,11 @@
 	else
 		suit_store = /obj/item/gun/projectile/automatic/m22/warmonger/m14/battlerifle/rsc
 		r_pocket =  /obj/item/ammo_magazine/a762/rsc
-		backpack_contents = list(/obj/item/ammo_magazine/a762/rsc = 4, /obj/item/grenade/smokebomb = 1, /obj/item/device/binoculars = 1)
+		backpack_contents = list(/obj/item/grenade/smokebomb = 1, /obj/item/device/binoculars = 1)
+		belt = /obj/item/storage/belt/armageddon)
 
 	if(aspect_chosen(/datum/aspect/nightfare))
-		backpack_contents += list(/obj/item/torch/self_lit = 1)
-		belt = /obj/item/ammo_box/flares/blue
+		backpack_contents += list(/obj/item/torch/self_lit = 1, /obj/item/ammo_box/flares/blue = 1)
 	..()
 
 /decl/hierarchy/outfit/job/bluesoldier/engineer

--- a/maps/oldfare/jobs/red/red_soldiers.dm
+++ b/maps/oldfare/jobs/red/red_soldiers.dm
@@ -244,7 +244,8 @@
 	else if (prob(5))
 		suit_store = /obj/item/gun/projectile/automatic/m22/warmonger/m14/battlerifle/rsc
 		r_pocket =  /obj/item/ammo_magazine/a762/rsc
-		backpack_contents = list(/obj/item/ammo_magazine/a762/rsc = 4, /obj/item/grenade/smokebomb = 1)
+		backpack_contents = list(/obj/item/grenade/smokebomb = 1)
+		belt = /obj/item/storage/belt/armageddon
 
 	else if(prob(25))
 		suit_store = /obj/item/gun/projectile/shotgun/pump/boltaction/shitty/leverchester
@@ -262,8 +263,7 @@
 		backpack_contents = list(/obj/item/grenade/smokebomb = 1)
 
 	if(aspect_chosen(/datum/aspect/nightfare))
-		backpack_contents += list(/obj/item/torch/self_lit = 1)
-		belt = /obj/item/ammo_box/flares
+		backpack_contents += list(/obj/item/torch/self_lit = 1, /obj/item/ammo_box/flares = 1)
 	..()
 
 /decl/hierarchy/outfit/job/redsoldier/sgt
@@ -279,11 +279,11 @@
 	else
 		suit_store = /obj/item/gun/projectile/automatic/m22/warmonger/m14/battlerifle/rsc
 		r_pocket =  /obj/item/ammo_magazine/a762/rsc
-		backpack_contents = list(/obj/item/ammo_magazine/a762/rsc = 4, /obj/item/grenade/smokebomb = 1, /obj/item/device/binoculars = 1)
+		backpack_contents = list(/obj/item/grenade/smokebomb = 1, /obj/item/device/binoculars = 1)
+		belt = /obj/item/storage/belt/armageddon
 
 	if(aspect_chosen(/datum/aspect/nightfare))
-		backpack_contents += list(/obj/item/torch/self_lit = 1)
-		belt = /obj/item/ammo_box/flares
+		backpack_contents += list(/obj/item/torch/self_lit = 1, /obj/item/ammo_box/flares = 1)
 	..()
 
 

--- a/maps/oldfare/warfare_items.dm
+++ b/maps/oldfare/warfare_items.dm
@@ -503,6 +503,22 @@
 		new /obj/item/ammo_magazine/mc9mmt/machinepistol(src)
 		new /obj/item/ammo_magazine/mc9mmt/machinepistol(src)
 
+/obj/item/storage/belt/armageddon
+	name = "ammo belt"
+	desc = "Great for holding ammo! This one starts with Armageddon ammo."
+	icon_state = "warfare_belt"
+	item_state = "warfare_belt"
+	can_hold = list(
+		/obj/item/ammo_magazine,
+		)
+
+	New()
+		..()
+		new /obj/item/ammo_magazine/a762/rsc(src)
+		new /obj/item/ammo_magazine/a762/rsc(src)
+		new /obj/item/ammo_magazine/a762/rsc(src)
+		new /obj/item/ammo_magazine/a762/rsc(src)
+
 /obj/item/storage/belt/warfare/chestrig
 	name = "Chestrig"
 	desc = "Holds ammo. But not much else."


### PR DESCRIPTION
This adds an ammo belt that has 4 armaggedon magazines and removes those pre-existing magazines in satchels from those spawn with Armageddon and gave them said belt with their ammo. I also moved where flares spawn for soldiers and sergeants to their satchels so there is no complication from the belt and flares spawning that same slot.