### PR TITLE
You can now Alt-click on storage containers to look inside them

### DIFF
--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -282,6 +282,15 @@
 	src.add_fingerprint(user)
 	return
 
+/obj/item/storage/AltClick(mob/user)
+	if(user.incapacitated())
+		to_chat(user, "<span class='warning'>You can't do that right now!</span>")
+		return
+	if(!in_range(src, user))
+		return
+	else
+		src.open(user)
+
 /obj/item/storage/proc/gather_all(var/turf/T, var/mob/user)
 	var/success = 0
 	var/failure = 0


### PR DESCRIPTION
I was surprised this feature wasn't here.
The only way to do this at the moment that I could find was to drag the container to your body.
This functionality works really well in other codebases.

This works for literally any storage containers like cigarette packs, backpacks, medkits, matchboxes etc

![v4tWCySMCr](https://user-images.githubusercontent.com/24533979/108281384-40df7300-7145-11eb-8403-09e71b5580fb.gif)
