### PR TITLE
Moved the backpack back check to a better place

### DIFF
--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -40,11 +40,11 @@
 	..(user, slot)
 
 
-/obj/item/storage/backpack/attack_hand(mob/user)
+/obj/item/storage/backpack/open(mob/user)
 	if(src == user.back && !is_satchel)  // you have to hold backpacks, sorry my guys
 		to_chat(user, "You cannot reach into \the [src] while it's on your back.")
 		return
-	..()
+	. = ..()
 
 
 /*


### PR DESCRIPTION
some nerd put the backpack check in attack_hand() instead of open() for some reason meaning that it bypasses the check if you open the backpack via any other means