### PR TITLE
Practitioners start with their penlight on their ear vs their pocket

### DIFF
--- a/code/datums/outfits/jobs/medical.dm
+++ b/code/datums/outfits/jobs/medical.dm
@@ -24,7 +24,7 @@
 	uniform = /obj/item/clothing/under/rank/medical
 	suit = /obj/item/clothing/suit/storage/doctor_vest
 	l_hand = /obj/item/storage/firstaid/adv
-	r_pocket = /obj/item/device/flashlight/pen
+	r_ear = /obj/item/device/flashlight/pen
 	id_type = /obj/item/card/id/medical
 
 /decl/hierarchy/outfit/job/medical/doctor/emergency_physician


### PR DESCRIPTION
Not sure why this code is located all the way in this file but starting the pen on the ear vs the pocket is more intuitive as it frees up the pocket (and is probably done by people as they spawn in any way)

That or they throw it away

![Kzg5belB6e](https://user-images.githubusercontent.com/24533979/108779767-04d55500-752d-11eb-86e6-53ce2fe0144e.png)
