### PR TITLE
Fixes boombox music glitch

### DIFF
--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -133,9 +133,15 @@
 	if(deaf_loop)
 		sound_to(src, sound(null, repeat = 1, volume = 50, wait = 0, channel = 1))
 		ambience_is_playing = FALSE
+		for(var/datum/sound_token/ST)
+			ST.listener_status[src] |= SOUND_MUTE
+			ST.PrivUpdateListener(src)
 	else if(!deaf_loop && !ambience_is_playing)
 		ambience_is_playing = TRUE
 		sound_to(src, sound(current_ambience, repeat = 1, volume = 50, wait = 0, channel = 1))
+		for(var/datum/sound_token/ST)
+			ST.listener_status[src] &= ~SOUND_MUTE
+			ST.PrivUpdateListener(src)
 
 
 /mob/living/proc/change_current_ambience(var/ambience)

--- a/code/modules/mob/observer/ghost/ghost.dm
+++ b/code/modules/mob/observer/ghost/ghost.dm
@@ -175,6 +175,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		announce_ghost_joinleave(ghostize(1))
 	else
 		succumb()
+
 	/*
 	else
 		var/response
@@ -485,13 +486,13 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 
 	if(admin_ghosted)//aghosts can always respawn if they like
 		return TRUE
-	
+
 	if(issiegefare() && client.warfare_faction == RED_TEAM)
 		return TRUE
-		
+
 	if(issiegefare())
 		respawn_time = 0.5
-	
+
 	/*
 	if(mind && mind.current && mind.current.stat != DEAD && can_reenter_corpse == CORPSE_CAN_REENTER)
 		if(feedback)
@@ -579,3 +580,6 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	var/mob/new_player/M = new /mob/new_player()
 	M.key = key
 	log_and_message_admins("has respawned.", M)
+	for(var/datum/sound_token/ST) // Removing from listeners list in sound_player.dm so music won't bother new_player in lobby after respawn
+		ST.PrivRemoveListener(src) // Better safe than sorry
+		ST.PrivRemoveListener(M)


### PR DESCRIPTION
Fixes #56
A bit clunky, but now boombox music won't play on loop after respawn. Also deaf mobs no longer hear boombox music too.