### PR TITLE
Fixes blindness and blurry vision

### DIFF
--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -409,23 +409,29 @@ The slots that you can use are found in items_clothing.dm and are the inventory 
 	if(!H.client)//no client, no screen to update
 		return 1
 
-	//H.set_fullscreen(H.eye_blind && !H.equipment_prescription, "blind", /obj/screen/fullscreen/blind)
+	H.set_fullscreen(H.eye_blind && !H.equipment_prescription, "blind", /obj/screen/fullscreen/blind)
+
+	/*
+	This piece of code breaking mob's FOV.
 	if(H.eye_blind && !H.equipment_prescription)
 		H.set_all_blur()
 	else
 		H.remove_all_blur()
-
+	*/
 	H.set_fullscreen(H.stat == UNCONSCIOUS, "blackout", /obj/screen/fullscreen/blackout)
 
 	//if(config.welder_vision)
 	//	H.set_fullscreen(H.equipment_tint_total, "welder", /obj/screen/fullscreen/impaired, H.equipment_tint_total)
 	var/how_nearsighted = get_how_nearsighted(H)
 	H.set_fullscreen(how_nearsighted, "nearsighted", /obj/screen/fullscreen/oxy, how_nearsighted)
-	//H.set_fullscreen(H.eye_blurry, "blurry", /obj/screen/fullscreen/blurry)
+	H.set_fullscreen(H.eye_blurry, "blurry", /obj/screen/fullscreen/blurry)
+
+	/* This one too.
 	if(H.eye_blurry)
 		H.set_all_blur()
 	else
 		H.remove_all_blur()
+	*/
 	H.set_fullscreen(H.druggy, "high", /obj/screen/fullscreen/high)
 
 	for(var/overlay in H.equipment_overlays)

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -185,7 +185,13 @@
 
 	return 1
 
-//I hate this with a burning passion.
+/*
+	I hate this with a burning passion.
+
+
+	If you want this cool blur effect you can uncomment this, but be aware of the weird glitch - blured icons of mobs will not be masked by vision_cone.
+	Blur filter(or any other filter) somehow interferes alpha mask filter on the same plane.
+
 /mob/living/proc/set_all_blur()
 	if(!client)
 		return
@@ -215,6 +221,7 @@
 	client.screen -= plating_blur
 	client.screen -= AT
 	client.screen -= AOB
+*/
 
 /mob/living/proc/handle_vision()
 	update_sight()

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -63,7 +63,10 @@
 	var/datum/trait/trait = null
 	var/fast_stripper = FALSE //whether or not you can turbostrip
 
+	/*
 	//This is for the screen. Yes I hate this. Yes I know it needs a refactor. No I don't care at the moment.
+	//
+	//Comment this out until better times.
 	var/obj/screen/plane_master/blur/human_blur/HB = new
 	var/obj/screen/plane_master/blur/turf_blur/TB = new
 	var/obj/screen/plane_master/blur/wall_blur/WB = new
@@ -75,3 +78,4 @@
 	var/obj/screen/plane_master/blur/effects_blur/EB = new
 	var/obj/screen/plane_master/blur/plating_blur/plating_blur = new
 	var/obj/screen/plane_master/blur/above_obj_blur/AOB = new
+	*/


### PR DESCRIPTION
Fixes #54

Let me explain.
When client's mob get some damage to the eyes, a blur filter applied to client's screen. After that, blur filter(or any other filter) start to interfere alpha mask filter just because it share the same plane with alpha mask filter. It looks like this:

![image](https://user-images.githubusercontent.com/70969776/207373455-f7d50a13-9412-4f2d-a88f-14d81a5cea96.png)
As you can see - there is mob right behind the character.

I don't think it's currently possible to get these filters to work together correctly.  So we have to downgrade to the old set_fullscreen mechanic to make FOV mask work properly.

![image](https://user-images.githubusercontent.com/70969776/207375772-b876c144-c915-4d83-9270-240f60436853.png)

