### PR TITLE
You can now write on the back of photos again

### DIFF
--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -59,10 +59,16 @@ var/global/photo_count = 0
 
 /obj/item/photo/attackby(obj/item/P as obj, mob/user as mob)
 	if(istype(P, /obj/item/pen))
-		var/txt = sanitize(user, "What would you like to write on the back?", "Photo Writing", null)
 		if(loc == user && user.stat == 0)
-			scribble = txt
+			var/txt = sanitize(input(user, "What would you like to write on the back?", "Photo Writing", null))
+			if(loc == user && user.stat == 0)
+				scribble = txt
+				return
+			to_chat(usr,"<span class='notice'>I need to hold the photo in my hands to write on the back!</span>")
+			return
+		to_chat(usr,"<span class='notice'>I need to hold the photo in my hands to write on the back!</span>")
 	..()
+
 
 /obj/item/photo/examine(mob/user)
 	if(in_range(user, src))


### PR DESCRIPTION
Fixed an issue where the input box to set the scribble doesn't appear, alongside an issue where the requirement to have the photo in your hands to scribble on it isn't conveyed clearly.

This will be very useful for whenever you need to write on the back of a photo. In an environment where pens and cameras are nearly non-existent. 