### PR TITLE
Bugfix for Sentry Deployment

### DIFF
--- a/code/game/gamemodes/warfare/turfs.dm
+++ b/code/game/gamemodes/warfare/turfs.dm
@@ -97,6 +97,37 @@
 	user.visible_message("<span class='warning'>[user] climbed onto \the [src]!</span>")
 	climbers -= user
 
+/turf/simulated/floor/do_climb(var/mob/living/user)
+	if(!can_climb(user))
+		return
+
+	if(istype(get_area(src), /area/warfare))//We're trying to go?
+		if(locate(/obj/item/gun/projectile/automatic/mg08) in user)//Locate the mg.
+			if(istype(usr.l_hand, /obj/item/gun/projectile/automatic/mg08) || istype(usr.r_hand, /obj/item/gun/projectile/automatic/mg08))
+				to_chat(user, "I can't climb with this in my hands!")//No you fucking don't.
+				return //Keep that mg stowed asshole.
+		//if(locate(/obj/item/storage) in user)//Gotta check storage as well.
+		//	var/obj/item/storage/S = locate() in user
+		//	if(locate(/obj/item/gun/projectile/automatic/mg08) in S)
+		//		to_chat(user, "I can't bring this with me onto the battlefield, it's too expensive!")
+		//		return
+
+	user.visible_message("<span class='warning'>[user] starts climbing onto \the [src]!</span>")
+	climbers |= user
+
+	if(!can_climb(user))
+		climbers -= user
+		return
+
+	if(!do_after(user,15))
+		climbers -= user
+		return
+
+	user.forceMove(get_turf(src))
+	user.visible_message("<span class='warning'>[user] climbed onto \the [src]!</span>")
+	climbers -= user
+
+
 /turf/simulated/floor/MouseDrop_T(mob/target, mob/user)
 	var/mob/living/H = user
 	if(istype(H) && can_climb(H) && target == user)

--- a/code/game/gamemodes/warfare/turfs.dm
+++ b/code/game/gamemodes/warfare/turfs.dm
@@ -106,11 +106,6 @@
 			if(istype(usr.l_hand, /obj/item/gun/projectile/automatic/mg08) || istype(usr.r_hand, /obj/item/gun/projectile/automatic/mg08))
 				to_chat(user, "I can't climb with this in my hands!")//No you fucking don't.
 				return //Keep that mg stowed asshole.
-		//if(locate(/obj/item/storage) in user)//Gotta check storage as well.
-		//	var/obj/item/storage/S = locate() in user
-		//	if(locate(/obj/item/gun/projectile/automatic/mg08) in S)
-		//		to_chat(user, "I can't bring this with me onto the battlefield, it's too expensive!")
-		//		return
 
 	user.visible_message("<span class='warning'>[user] starts climbing onto \the [src]!</span>")
 	climbers |= user

--- a/code/modules/projectiles/guns/projectile/mattguns.dm
+++ b/code/modules/projectiles/guns/projectile/mattguns.dm
@@ -347,14 +347,14 @@
 /obj/item/gun/projectile/automatic/mg08/attack_self(mob/user)
 	. = ..()
 	if(deployed)//If there's an mg deployed, then pack it up again.
-		pack_up_mortar(user)
+		pack_up_mg(user)
 	else
-		deploy_mortar(user)//Otherwise, deploy that motherfucker.
+		deploy_mg(user)//Otherwise, deploy that motherfucker.
 
-/obj/item/gun/projectile/automatic/mg08/proc/deploy_mortar(mob/user)
+/obj/item/gun/projectile/automatic/mg08/proc/deploy_mg(mob/user)
 	for(var/obj/structure/mg08_structure/M in user.loc)//If there's already an mg there then don't deploy it. Dunno how that's possible but stranger things have happened.
 		if(M)
-			to_chat(user, "There is already a mortar here.")
+			to_chat(user, "There is already an LMG here.")
 			return
 	user.visible_message("[user] starts to deploy the [src]")
 	if(!do_after(user,30))
@@ -372,10 +372,11 @@
 			user.pixel_y += 5
 			M.plane = ABOVE_HUMAN_PLANE
 	deployed = TRUE
-	playsound(src, 'sound/weapons/mortar_deploy.ogg', 100, FALSE)
+	playsound(src, 'sound/weapons/mg_deploy.ogg', 100, FALSE)
+//	can_climb(user) = FALSE
 	update_icon(user)
 
-/obj/item/gun/projectile/automatic/mg08/proc/pack_up_mortar(mob/user)
+/obj/item/gun/projectile/automatic/mg08/proc/pack_up_mg(mob/user)
 	user.visible_message("[user] packs up the [src]")
 	for(var/obj/structure/mg08_structure/M in user.loc)
 		switch(M.dir)//Set our offset back to normal.
@@ -389,19 +390,26 @@
 				user.pixel_y -= 5
 		qdel(M) //Delete the mg structure.
 	deployed = FALSE
+	//can_climb(user) = TRUE
 	update_icon(user)
 
 /obj/item/gun/projectile/automatic/mg08/dropped(mob/user)
 	. = ..()
 	if(deployed)
-		pack_up_mortar(user)
+		pack_up_mg(user)
+
+/obj/item/gun/projectile/automatic/mg08/equipped(var/mob/user, var/slot)
+	..()
+	if((slot == slot_back) || (slot == slot_s_store))
+		. = ..()
+		if(deployed)
+			pack_up_mg(user)
 
 /obj/structure/mg08_structure //That thing that's created when you place down your mg, purely for looks.
-	name = "Deployed HE Trench Ender"
+	name = "Deployed LMG Harbinger"
 /*
 	icon = 'icons/obj/items/mg08.dmi'
 	icon_state = "mg08_structure"
-//invisible but hopefully that don't cause no problems
 	*/
 	anchored = TRUE //No moving this around please.
 

--- a/code/modules/projectiles/guns/projectile/mattguns.dm
+++ b/code/modules/projectiles/guns/projectile/mattguns.dm
@@ -387,7 +387,7 @@
 				user.pixel_y += 5
 			if(SOUTH)
 				user.pixel_y -= 5
-		qdel(M) //Delete the mortar structure.
+		qdel(M) //Delete the mg structure.
 	deployed = FALSE
 	update_icon(user)
 
@@ -396,11 +396,12 @@
 	if(deployed)
 		pack_up_mortar(user)
 
-/obj/structure/mg08_structure //That thing that's created when you place down your mortar, purely for looks.
+/obj/structure/mg08_structure //That thing that's created when you place down your mg, purely for looks.
 	name = "Deployed HE Trench Ender"
 /*
 	icon = 'icons/obj/items/mg08.dmi'
 	icon_state = "mg08_structure"
+//invisible but hopefully that don't cause no problems
 	*/
 	anchored = TRUE //No moving this around please.
 

--- a/code/modules/projectiles/guns/projectile/mattguns.dm
+++ b/code/modules/projectiles/guns/projectile/mattguns.dm
@@ -390,7 +390,6 @@
 				user.pixel_y -= 5
 		qdel(M) //Delete the mg structure.
 	deployed = FALSE
-	//can_climb(user) = TRUE
 	update_icon(user)
 
 /obj/item/gun/projectile/automatic/mg08/dropped(mob/user)

--- a/code/modules/projectiles/guns/projectile/mattguns.dm
+++ b/code/modules/projectiles/guns/projectile/mattguns.dm
@@ -373,7 +373,6 @@
 			M.plane = ABOVE_HUMAN_PLANE
 	deployed = TRUE
 	playsound(src, 'sound/weapons/mg_deploy.ogg', 100, FALSE)
-//	can_climb(user) = FALSE
 	update_icon(user)
 
 /obj/item/gun/projectile/automatic/mg08/proc/pack_up_mg(mob/user)
@@ -406,10 +405,6 @@
 
 /obj/structure/mg08_structure //That thing that's created when you place down your mg, purely for looks.
 	name = "Deployed LMG Harbinger"
-/*
-	icon = 'icons/obj/items/mg08.dmi'
-	icon_state = "mg08_structure"
-	*/
 	anchored = TRUE //No moving this around please.
 
 /obj/structure/mg08/CanPass(atom/movable/mover, turf/target, height, air_group)//Humans cannot pass cross this thing in any way shape or form.
@@ -427,13 +422,7 @@
 
 /obj/structure/mg08_structure/rotate/proc/rotate()//Can't rotate it.
 	return
-//Tried removing above two, did nothing.
-/*
-/obj/item/gun/projectile/automatic/mg08/special_check(var/mob/user)
-	to_chat(user, "It just doesn't seem to work.")
-	handle_click_empty(user)
-	return 0
-*/
+
 /obj/item/gun/projectile/automatic/gpmg
 	name = "GPMG Requiem"
 	desc = "A coveted LMG. Lighter than the Harbingers of the old war, but still just as deadly!"

--- a/maps/oldfare/jobs/blue/blue_soldiers.dm
+++ b/maps/oldfare/jobs/blue/blue_soldiers.dm
@@ -139,7 +139,7 @@
 
 /datum/job/soldier/blue_soldier/sentry
 	title = "Blue Sentry"
-	total_positions = 0
+	total_positions = 1
 	outfit_type = /decl/hierarchy/outfit/job/bluesoldier/sentry
 	auto_rifle_skill = 5
 	semi_rifle_skill = 5

--- a/maps/oldfare/jobs/red/red_soldiers.dm
+++ b/maps/oldfare/jobs/red/red_soldiers.dm
@@ -113,7 +113,7 @@
 
 /datum/job/soldier/red_soldier/sentry
 	title = "Red Sentry"
-	total_positions = 0
+	total_positions = 1
 	outfit_type = /decl/hierarchy/outfit/job/redsoldier/sentry
 	auto_rifle_skill = 5
 	semi_rifle_skill = 5


### PR DESCRIPTION
Most warfare turfs are climbable even if you're not in a trench, so you were able to escape a deployed sentry while still having it be deployed to make an invisible trap. Now you can't climb with a sentry in your hands (deployed or undeployed) and putting it on your back undeploys it. That should fix any loopholes to escape a deployed sentry without it undeploying.